### PR TITLE
Optional input and adjusted defaults

### DIFF
--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -50,8 +50,8 @@ jobs:
           # These options should be enabled
           kubectl get --namespace kube-system deploy metrics-server
           # Problem with 1.16, ignore since it'll be dropped soon
-          if [[ ${{ matrix.k3s }} != v1.16.* ]]; then
-            kubectl get --namespace kube-system deploy traefik
+          if [[ "${{ matrix.k3s }}" != v1.16.* ]]; then
+              kubectl get --namespace kube-system deploy traefik
           fi
         shell: bash
 

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -39,6 +39,7 @@ jobs:
           helm-version: ${{ matrix.helm }}
           metrics-enabled: true
           traefik-enabled: true
+          docker-enabled: false
       # This action should export KUBECONFIG
 
       - name: Kubectl
@@ -76,6 +77,8 @@ jobs:
       - id: k3s
         uses: ./
         with:
+          k3s-version: ""
+          helm-version: ""
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: true

--- a/.github/workflows/test_k3s.yml
+++ b/.github/workflows/test_k3s.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           k3s-version: ${{ matrix.k3s }}
           helm-version: ${{ matrix.helm }}
+          metrics-enabled: true
+          traefik-enabled: true
       # This action should export KUBECONFIG
 
       - name: Kubectl

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Install K3s with Calico for network policies, and Helm 3.
 
 ## Optional input parameters
 - `k3s-version`: K3s version, see https://github.com/rancher/k3s/releases.
-   Versions 1.16 and later are supported.
+   Versions 1.16 and later are supported. Defaults to the latest version.
 - `helm-version`: Helm version, see https://github.com/helm/helm/releases.
-   Versions 3.1 and later are supported.
-- `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`
-- `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`
-- `docker-enabled`: Use Docker for K3s, `true` or `false` (default)
+   Versions 3.1 and later are supported. Defaults to the latest version.
+- `metrics-enabled`: Enable or disable K3S metrics-server, `true` or `false` (default)
+- `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` or `false` (default)
+- `docker-enabled`: Enable K3s to use the Docker daemon, `true` or `false` (default)
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Install K3s with Calico for network policies, and Helm 3.
    Versions 1.16 and later are supported. Defaults to the latest version.
 - `helm-version`: Helm version, see https://github.com/helm/helm/releases.
    Versions 3.1 and later are supported. Defaults to the latest version.
-- `metrics-enabled`: Enable or disable K3S metrics-server, `true` or `false` (default)
-- `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` or `false` (default)
-- `docker-enabled`: Enable K3s to use the Docker daemon, `true` or `false` (default)
+- `metrics-enabled`: Enable or disable K3S metrics-server, `true` (default) or `false`.
+- `traefik-enabled`: Enable or disable K3S Traefik ingress, `true` (default) or `false`.
+- `docker-enabled`: Enable K3s to use the Docker daemon, `true` or `false` (default).
 
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -57,21 +57,21 @@ runs:
     #       --disable.
     - name: Setup k3s ${{ inputs.k3s-version }}
       run: |
-        if [[ ${{ inputs.k3s-version }} == v1.16.* ]]; then
+        if [[ "${{ inputs.k3s-version }}" == "v1.16.*" ]]; then
           k3s_disable_command=--no-deploy
         else
           k3s_disable_command=--disable
         fi
-        if [[ ${{ inputs.metrics-enabled }} != true ]]; then
+        if [[ "${{ inputs.metrics-enabled }}" != "true" ]]; then
           k3s_disable_metrics="${k3s_disable_command} metrics-server"
         fi
-        if [[ ${{ inputs.traefik-enabled }} != true ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" != "true" ]]; then
           k3s_disable_traefik="${k3s_disable_command} traefik"
         fi
-        if [[ ${{ inputs.docker-enabled }} == true ]]; then
+        if [[ "${{ inputs.docker-enabled }}" == "true" ]]; then
           k3s_docker=--docker
         fi
-        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${{ inputs.k3s-version }} sh -s - \
+        curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" sh -s - \
           --write-kubeconfig-mode=644 \
           ${k3s_disable_metrics} \
           ${k3s_disable_traefik} \
@@ -106,7 +106,7 @@ runs:
     # install Helm at this point for example.
     - name: Setup Helm ${{ inputs.helm-version }}
       run: |
-        curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION=${{ inputs.helm-version }} bash
+        curl -sf https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | DESIRED_VERSION="${{ inputs.helm-version }}" bash
       shell: bash
 
     - name: Wait for calico
@@ -120,11 +120,11 @@ runs:
     - name: Wait for coredns, metrics server, traefik
       run: |
         kubectl rollout status --watch --timeout 300s deployment/coredns -n kube-system
-        if [[ ${{ inputs.metrics-enabled }} == true ]]; then
+        if [[ "${{ inputs.metrics-enabled }}" == "true" ]]; then
           kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
         fi
         # Problem with 1.16, ignore since it'll be dropped soon
-        if [[ ${{ inputs.traefik-enabled }} == true && ${{ inputs.k3s-version }} != v1.16.* ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" == "true" && "${{ inputs.k3s-version }}" != "v1.16.*" ]]; then
           kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
         fi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -18,21 +18,21 @@ inputs:
   k3s-version:
     description: K3S version (https://github.com/rancher/k3s/releases)
     required: false
-    default: v1.19.3+k3s1
+    default: ""
   helm-version:
     description: Helm 3 version (https://github.com/helm/helm/releases)
     required: false
-    default: v3.3.4
+    default: ""
   metrics-enabled:
     description: Enable or disable K3S metrics-server
     required: false
-    default: "true"
+    default: "false"
   traefik-enabled:
     description: Enable or disable K3S Traefik ingress
     required: false
-    default: "true"
+    default: "false"
   docker-enabled:
-    description: Use Docker for K3s
+    description: Enable K3s to use the Docker daemon
     required: false
     default: "false"
 

--- a/action.yml
+++ b/action.yml
@@ -17,23 +17,23 @@ branding:
 inputs:
   k3s-version:
     description: K3S version (https://github.com/rancher/k3s/releases)
-    required: true
+    required: false
     default: v1.19.3+k3s1
   helm-version:
     description: Helm 3 version (https://github.com/helm/helm/releases)
-    required: true
+    required: false
     default: v3.3.4
   metrics-enabled:
     description: Enable or disable K3S metrics-server
-    required: true
+    required: false
     default: "true"
   traefik-enabled:
     description: Enable or disable K3S Traefik ingress
-    required: true
+    required: false
     default: "true"
   docker-enabled:
     description: Use Docker for K3s
-    required: true
+    required: false
     default: "false"
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -26,11 +26,11 @@ inputs:
   metrics-enabled:
     description: Enable or disable K3S metrics-server
     required: false
-    default: "false"
+    default: "true"
   traefik-enabled:
     description: Enable or disable K3S Traefik ingress
     required: false
-    default: "false"
+    default: "true"
   docker-enabled:
     description: Enable K3s to use the Docker daemon
     required: false

--- a/action.yml
+++ b/action.yml
@@ -57,18 +57,18 @@ runs:
     #       --disable.
     - name: Setup k3s ${{ inputs.k3s-version }}
       run: |
-        if [[ "${{ inputs.k3s-version }}" == "v1.16.*" ]]; then
+        if [[ "${{ inputs.k3s-version }}" == v1.16.* ]]; then
           k3s_disable_command=--no-deploy
         else
           k3s_disable_command=--disable
         fi
-        if [[ "${{ inputs.metrics-enabled }}" != "true" ]]; then
+        if [[ "${{ inputs.metrics-enabled }}" != true ]]; then
           k3s_disable_metrics="${k3s_disable_command} metrics-server"
         fi
-        if [[ "${{ inputs.traefik-enabled }}" != "true" ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" != true ]]; then
           k3s_disable_traefik="${k3s_disable_command} traefik"
         fi
-        if [[ "${{ inputs.docker-enabled }}" == "true" ]]; then
+        if [[ "${{ inputs.docker-enabled }}" == true ]]; then
           k3s_docker=--docker
         fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="${{ inputs.k3s-version }}" sh -s - \
@@ -120,11 +120,11 @@ runs:
     - name: Wait for coredns, metrics server, traefik
       run: |
         kubectl rollout status --watch --timeout 300s deployment/coredns -n kube-system
-        if [[ "${{ inputs.metrics-enabled }}" == "true" ]]; then
+        if [[ "${{ inputs.metrics-enabled }}" == true ]]; then
           kubectl rollout status --watch --timeout 300s deployment/metrics-server -n kube-system
         fi
         # Problem with 1.16, ignore since it'll be dropped soon
-        if [[ "${{ inputs.traefik-enabled }}" == "true" && "${{ inputs.k3s-version }}" != "v1.16.*" ]]; then
+        if [[ "${{ inputs.traefik-enabled }}" == true && "${{ inputs.k3s-version }}" != v1.16.* ]]; then
           kubectl rollout status --watch --timeout 300s deployment/traefik -n kube-system
         fi
       shell: bash


### PR DESCRIPTION
I think the k3s-version and helm-version defaults really should be blank and therefore become the latest k3s / helm version, but I also opined on the other flags where I'm more open to leaving at it is if you think so @manics.

I would argue for having metrics/traefik-enabled flags to be false by default as they add some weight to the installation, which I think can merit an opt-in rather than opt-out.
